### PR TITLE
Fix #26: simplify tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,10 +74,10 @@ using them for closed-box (black-box) testing of the modifiers.
 
 Each test file contains, in this order:
 1. helper functions
-1. fixtures (functions that generate test data)
-1. tests for creator methods
-1. tests for modifier methods, used separately, and finally
-1. tests for combined use of modifiers.
+2. test data
+3. tests for creator methods
+4. tests for modifier methods, used separately, and finally
+5. tests for combined use of modifiers.
 
 Additionally, there are simple interactive examples of how to use a class in that class's docstring,
 in subfolder `paddles`. These are used as [doctests](https://docs.python.org/3.10/library/doctest.html).

--- a/tests/test_deque.py
+++ b/tests/test_deque.py
@@ -25,26 +25,19 @@ def check_is_empty(deque: DequeADT) -> None:
     assert str(deque) == f"{deque.__class__.__name__}([])"
 
 
-# Fixtures: functions that return the data for testing the queue operations.
-
-
-@pytest.fixture(params=[LinkedListDeque])
-def Deque(request: pytest.FixtureRequest) -> type[DequeADT]:  # noqa: N802
-    """Return an implementation (a class) to be tested."""
-    return request.param
-
-
-@pytest.fixture(params=["abcd", [1, 2, 3], (True, False, None), range(20)])
-def sequence(request: pytest.FixtureRequest) -> Sequence:
-    """Return a sequence of items to test with."""
-    return request.param
-
+# Execute each test for all combinations of these parameter values.
+pytestmark = [
+    pytest.mark.parametrize("Deque", [LinkedListDeque]),
+    pytest.mark.parametrize(
+        "sequence", ["abcd", [3, 2, 1], (True, False, None), range(20)]
+    ),
+]
 
 # Test the creation method.
 
 
-def test_init_empty(Deque: type[DequeADT]) -> None:  # noqa: N803
-    """Test the creation of empty deques."""
+def test_init_empty(Deque: type[DequeADT], sequence: Sequence) -> None:  # noqa: N803 ARG001
+    """Test the creation of empty deques. Ignore the sequence for this test."""
     check_is_empty(Deque())
 
 

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -21,26 +21,20 @@ def check_is_empty(queue: QueueADT) -> None:
     assert str(queue) == f"{queue.__class__.__name__}([])"
 
 
-# Fixtures: functions that return the data for testing the queue operations.
-
-
-@pytest.fixture(params=[LinkedListQueue])
-def Queue(request: pytest.FixtureRequest) -> type[QueueADT]:  # noqa: N802
-    """Return an implementation (a class) to be tested."""
-    return request.param
-
-
-@pytest.fixture(params=["abcd", [1, 2, 3], (True, False, None), range(20)])
-def sequence(request: pytest.FixtureRequest) -> Sequence:
-    """Return a sequence of items to test with."""
-    return request.param
+# Execute each test for all combinations of these parameter values.
+pytestmark = [
+    pytest.mark.parametrize("Queue", [LinkedListQueue]),
+    pytest.mark.parametrize(
+        "sequence", ["abcd", [3, 2, 1], (True, False, None), range(20)]
+    ),
+]
 
 
 # Test the creation method.
 
 
-def test_init_empty(Queue: type[QueueADT]) -> None:  # noqa: N803
-    """Test the creation of empty queues."""
+def test_init_empty(Queue: type[QueueADT], sequence: Sequence) -> None:  # noqa: N803 ARG001
+    """Test the creation of empty queues. Ignore the sequence."""
     check_is_empty(Queue())
 
 

--- a/tests/test_sorting.py
+++ b/tests/test_sorting.py
@@ -22,20 +22,6 @@ SortFunction = Callable[[list], None]
 # Functions named `..._sorted` take an iterable collection and return a new sorted list.
 SortedFunction = Callable[[Iterable], list]
 
-# Fixtures: functions that return the data for testing the sorting functions.
-
-
-@pytest.fixture(params=[tim_sort])
-def sort_function(request: pytest.FixtureRequest) -> SortFunction:
-    """Return an in-place sorting function to be tested."""
-    return request.param
-
-
-@pytest.fixture(params=[])
-def sorted_function(request: pytest.FixtureRequest) -> SortedFunction:
-    """Return a sorting function to be tested that isn't in-place."""
-    return request.param
-
 
 # fmt: off
 LISTS = [
@@ -60,22 +46,11 @@ OTHER = [
 ]
 # fmt: on
 
-
-@pytest.fixture(params=[[5, 4, 3], [2, 7, -1]])
-def sequence(request: pytest.FixtureRequest) -> list:
-    """Return a list of items to test with."""
-    return request.param
-
-
-@pytest.fixture(params=LISTS + OTHER)
-def iterable(request: pytest.FixtureRequest) -> Iterable:
-    """Return an iterable collection of items to test with."""
-    return request.param
-
-
 # Test the sorting algorithms.
 
 
+@pytest.mark.parametrize("sort_function", [tim_sort])
+@pytest.mark.parametrize("sequence", LISTS)
 def test_sort(sort_function: SortFunction, sequence: list) -> None:
     """Test function `sort`, which sorts a list in-place, with `sequence`."""
     # Copy the input, so that subsequent functions don't get already sorted lists.
@@ -84,6 +59,8 @@ def test_sort(sort_function: SortFunction, sequence: list) -> None:
     assert is_non_decreasing(items)
 
 
+@pytest.mark.parametrize("sorted_function", [])
+@pytest.mark.parametrize("iterable", LISTS + OTHER)
 def test_sorted(sorted_function: SortedFunction, iterable: Iterable) -> None:
     """Test function `sorted`, which returns a new sorted list, with `iterable`."""
     assert is_non_decreasing(sorted_function(iterable))

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -21,26 +21,22 @@ def check_is_empty(stack: StackADT) -> None:
     assert str(stack) == f"{stack.__class__.__name__}([])"
 
 
-# Fixtures: functions that return the data for testing the stack operations.
-
-
-@pytest.fixture(params=[DynamicArrayStack, LinkedListStack])
-def Stack(request: pytest.FixtureRequest) -> type[StackADT]:  # noqa: N802
-    """Return an implementation (a class) to be tested."""
-    return request.param
-
-
-@pytest.fixture(params=["abcd", [1, 2, 3], (True, False, None), range(20)])
-def sequence(request: pytest.FixtureRequest) -> Sequence:
-    """Return a sequence of items to test with."""
-    return request.param
-
+# Execute each test for all combinations of these parameter values.
+pytestmark = [
+    pytest.mark.parametrize("Stack", [LinkedListStack, DynamicArrayStack]),
+    pytest.mark.parametrize(
+        "sequence", ["abcd", [3, 2, 1], (True, False, None), range(20)]
+    ),
+]
 
 # Test the creation methods.
 
 
-def test_init_empty(Stack: type[StackADT]) -> None:  # noqa: N803
-    """Test the creation of empty stacks."""
+def test_init_empty(Stack: type[StackADT], sequence: Sequence) -> None:  # noqa: N803 ARG001
+    """Test the creation of empty stacks.
+
+    Ignore `sequence` as it's not needed for this one test.
+    """
     check_is_empty(Stack())
 
 


### PR DESCRIPTION
Replace non-explicit calls to parametrised fixtures with explicit marks